### PR TITLE
Minimum deployment target for Capacitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In the native ios project you will find two modules namely, 'App' and 'Pods' <br
 1. Select Pods <br/>
 2. Expand 'Development Pods' <br/>
 3. Expand 'Capacitor' and open 'CAPBridgeViewController.swift' <br/>
-4. Scroll to the very end of the file and paste the following method <br/>
+4. Scroll to the very end of the class and paste the following method <br/>
 ```
    public override func traitCollectionDidChange(\_ previousTraitCollection: UITraitCollection?) {
       if #available(iOS 13.0, \*) {
@@ -56,6 +56,7 @@ In the native ios project you will find two modules namely, 'App' and 'Pods' <br
       }
    }
 ```
+
 # Web Configuration <br/>
 ```
 import { Plugins } from '@capacitor/core';

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -29,7 +29,7 @@ public class DarkMode: CAPPlugin {
     @objc func isDarkModeOn(_ call: CAPPluginCall) {
         var isDarkModeOn = false
         DispatchQueue.main.async {
-            if self.bridge.bridgeDelegate.bridgedViewController?.traitCollection.userInterfaceStyle.rawValue == 2
+            if self.bridge?.viewController?.traitCollection.userInterfaceStyle.rawValue == 2
             {
                 isDarkModeOn = true
             }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks


### PR DESCRIPTION
This bumps the minimum deployment target to 12.0 as the latest Capacitor requires at least 12.0. I also adjusted the line to get the current traitCollection with the new Capacitor API.